### PR TITLE
fix syntax and formatting on examples of readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,10 +143,10 @@ noe -b junit -w 'test/*.js' -- 'test/*.js'
         var it = junit();
         (async () => {
             // Async tests.
-            it("test 1", () => {
+            it("test 1", () =>
                 // We use `it.eq` to assert on both simple type and complex object.
-                it.eq("ok", "ok");
-            });
+                it.eq("ok", "ok")
+            );
  
             it("test 2", async () => {
                 // No more callback hell while testing async functions.
@@ -161,7 +161,7 @@ noe -b junit -w 'test/*.js' -- 'test/*.js'
                     // do some clean work after the test
                 });
  
-                it.eq("ok", "ok");
+                return it.eq("ok", "ok");
             });
  
             it.run();

--- a/readme.md
+++ b/readme.md
@@ -143,12 +143,12 @@ noe -b junit -w 'test/*.js' -- 'test/*.js'
         var it = junit();
         (async () => {
             // Async tests.
-            it('test 1', () => {
+            it("test 1", () => {
                 // We use `it.eq` to assert on both simple type and complex object.
-                it.eq('ok', 'ok');
+                it.eq("ok", "ok");
             });
  
-            it('test 2', async () => {
+            it("test 2", async () => {
                 // No more callback hell while testing async functions.
                 await new junit.Promise(r => setTimeout(r, 1000));
  
@@ -156,12 +156,12 @@ noe -b junit -w 'test/*.js' -- 'test/*.js'
             });
  
             // Run sync tests within the main async flow.
-            await it('test 3', (after) => {
+            await it("test 3", (after) => {
                 after(() => {
                     // do some clean work after the test
                 });
  
-                it.eq('ok', 'ok');
+                it.eq("ok", "ok");
             });
  
             it.run();

--- a/readme.md
+++ b/readme.md
@@ -143,27 +143,27 @@ noe -b junit -w 'test/*.js' -- 'test/*.js'
         var it = junit();
         (async () => {
             // Async tests.
-            it("test 1", () =>
+            it('test 1', () => {
                 // We use `it.eq` to assert on both simple type and complex object.
-                it.eq("ok", "ok")
-            );
-
-            it("test 2", async () => {
+                it.eq('ok', 'ok');
+            });
+ 
+            it('test 2', async () => {
                 // No more callback hell while testing async functions.
                 await new junit.Promise(r => setTimeout(r, 1000));
-
+ 
                 return it.eq({ a: 1, b: 2 }, { a: 1, b: 2 });
             });
-
+ 
             // Run sync tests within the main async flow.
-            await it("test 3", (after) =>
+            await it('test 3', (after) => {
                 after(() => {
                     // do some clean work after the test
                 });
-
-                it.eq("ok", "ok")
-            );
-
+ 
+                it.eq('ok', 'ok');
+            });
+ 
             it.run();
         })();
         ```
@@ -174,7 +174,7 @@ noe -b junit -w 'test/*.js' -- 'test/*.js'
         ```js
         import junit from "junit";
         var it = junit({
-            filter: (msg) => msg.indexOf("test")
+            filter: (msg) => msg.indexOf("test");
         });
 
         (async () => {


### PR DESCRIPTION
- fix syntax errors: missing curly braces
- homogenize use of semicolons